### PR TITLE
Modify the typespec for functions push and push_list

### DIFF
--- a/lib/exponent_server_sdk/push_notification.ex
+++ b/lib/exponent_server_sdk/push_notification.ex
@@ -26,7 +26,7 @@ defmodule ExponentServerSdk.PushNotification do
   @doc """
   Send the push notification request when using a single message map
   """
-  @spec push(PushMessage.t()) :: Parser.success() | Parser.error()
+  @spec push(map) :: Parser.success() | Parser.error()
   def push(message) when is_map(message) do
     message
     |> PushMessage.create()
@@ -38,7 +38,7 @@ defmodule ExponentServerSdk.PushNotification do
   @doc """
   Send the push notification request when using a list of message maps
   """
-  @spec push_list(list(PushMessage.t())) :: Parser.success() | Parser.error()
+  @spec push_list(list(map)) :: Parser.success() | Parser.error()
   def push_list(messages) when is_list(messages) do
     messages
     |> PushMessage.create_from_list()

--- a/lib/exponent_server_sdk/push_notification.ex
+++ b/lib/exponent_server_sdk/push_notification.ex
@@ -38,7 +38,7 @@ defmodule ExponentServerSdk.PushNotification do
   @doc """
   Send the push notification request when using a list of message maps
   """
-  @spec push_list(list(map)) :: Parser.success() | Parser.error()
+  @spec push_list(list(map)) :: Parser.success_list() | Parser.error()
   def push_list(messages) when is_list(messages) do
     messages
     |> PushMessage.create_from_list()


### PR DESCRIPTION
Thanks for making this repo!

My dialyzer showed error "_breaks the contract_" when passing a **map** or **list(map)** as the argument for functions **PushNotification.push/1** and **PushNotification.push_list/1** respectively.

I found out that those functions were expecting the type **PushMessage.t()** instead of **map**.

Please let me know what do you guys think!

Kind Regards