### PR TITLE
use local structs for data push

### DIFF
--- a/lib/exponent_server_sdk/push_message.ex
+++ b/lib/exponent_server_sdk/push_message.ex
@@ -4,17 +4,18 @@ defmodule ExponentServerSdk.PushMessage do
   @moduledoc """
   Provides a basic payload structure to allow easy communication with the Exponent Push Notification.
   """
+  @derive [Poison.Encoder]
   @enforce_keys [:to]
   defstruct to: nil,
-            data: nil,
+            data: %{},
             title: nil,
             body: nil,
             ttl: 0,
-            expiration: nil,
+            expiration: 2419200,
             priority: "default",
             sound: "default",
-            badge: nil,
-            channelId: nil
+            badge: 1,
+            channelId: "Default"
 
   @typedoc """
       https://docs.expo.io/versions/v29.0.0/guides/push-notifications#message-format
@@ -137,7 +138,7 @@ defmodule ExponentServerSdk.PushMessage do
       iex> message_map = %{to: "ExponentPushToken[XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX]", title: "Pushed!", body: "You got your first message"}
       iex> message = ExponentServerSdk.PushMessage.create(message_map)
       iex> message
-      %ExponentServerSdk.PushMessage{badge: nil, body: "You got your first message", channelId: nil, data: nil, expiration: nil, priority: "default", sound: "default", title: "Pushed!", to: "ExponentPushToken[XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX]", ttl: 0}
+      %ExponentServerSdk.PushMessage{badge: 1, body: "You got your first message", channelId: "Default", data: %{}, expiration: 2419200, priority: "default", sound: "default", title: "Pushed!", to: "ExponentPushToken[XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX]", ttl: 0}
   """
   @spec create(map) :: PushMessage.t()
   def create(message) when is_map(message) do
@@ -151,7 +152,7 @@ defmodule ExponentServerSdk.PushMessage do
       iex> message_list = [%{to: "ExponentPushToken[XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX]", title: "Pushed!", body: "You got your first message"}, %{to: "ExponentPushToken[YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY]", title: "Pushed Again!", body: "You got your second message"}]
       iex> messages = ExponentServerSdk.PushMessage.create_from_list(message_list)
       iex> messages
-      [[%ExponentServerSdk.PushMessage{badge: nil, body: "You got your first message", channelId: nil, data: nil, expiration: nil, priority: "default", sound: "default", title: "Pushed!", to: "ExponentPushToken[XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX]", ttl: 0}, %ExponentServerSdk.PushMessage{ badge: nil, body: "You got your second message", channelId: nil, data: nil, expiration: nil, priority: "default", sound: "default", title: "Pushed Again!", to: "ExponentPushToken[YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY]", ttl: 0}]]
+      [[%ExponentServerSdk.PushMessage{badge: 1, body: "You got your first message", channelId: "Default", data: %{}, expiration: 2419200, priority: "default", sound: "default", title: "Pushed!", to: "ExponentPushToken[XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX]", ttl: 0}, %ExponentServerSdk.PushMessage{ badge: 1, body: "You got your second message", channelId: "Default", data: %{}, expiration: 2419200, priority: "default", sound: "default", title: "Pushed Again!", to: "ExponentPushToken[YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY]", ttl: 0}]]
   """
   @spec create_from_list(list(map)) :: list(PushMessage.t())
   def create_from_list(messages) when is_list(messages) do

--- a/lib/exponent_server_sdk/push_message.ex
+++ b/lib/exponent_server_sdk/push_message.ex
@@ -4,7 +4,6 @@ defmodule ExponentServerSdk.PushMessage do
   @moduledoc """
   Provides a basic payload structure to allow easy communication with the Exponent Push Notification.
   """
-  @derive [Poison.Encoder]
   @enforce_keys [:to]
   defstruct to: nil,
             data: %{},

--- a/lib/exponent_server_sdk/push_notification.ex
+++ b/lib/exponent_server_sdk/push_notification.ex
@@ -30,21 +30,27 @@ defmodule ExponentServerSdk.PushNotification do
   def push(message) when is_map(message) do
     message
     |> PushMessage.create()
-
-    PushNotification.post!("send", message)
+    |> PushNotification.post!("send", message)
     |> Parser.parse()
   end
 
   @doc """
   Send the push notification request when using a list of message maps
   """
-  @spec push_list(list(PushMessage.t())) :: Parser.success() | Parser.error()
+  @spec push_list(list()) :: list(Parser.success()) | list(Parser.error())
   def push_list(messages) when is_list(messages) do
     messages
-    |> PushMessage.create_from_list()
+    |> PushMessage.create_from_list
+    # |> Enum.chunk_every(100)
+    |> push_messages_list
+  end
 
-    PushNotification.post!("send", messages)
-    |> Parser.parse_list()
+  def push_messages_list([]), do: []
+
+  @spec push_messages_list(list(list(PushMessage.t()))) :: list(Parser.success()) | list(Parser.error())
+  def push_messages_list([head | tail]) do
+    current_message = PushNotification.post!("send", head) |> Parser.parse_list()
+    [ current_message | push_messages_list(tail) ]
   end
 
   @doc """
@@ -52,9 +58,6 @@ defmodule ExponentServerSdk.PushNotification do
   """
   @spec get_receipts(list()) :: Parser.success() | Parser.error()
   def get_receipts(ids) when is_list(ids) do
-    ids
-    |> PushMessage.create_receipt_id_list()
-
     PushNotification.post!("getReceipts", %{ids: ids})
     |> Parser.parse()
   end

--- a/lib/exponent_server_sdk/push_notification.ex
+++ b/lib/exponent_server_sdk/push_notification.ex
@@ -41,7 +41,6 @@ defmodule ExponentServerSdk.PushNotification do
   def push_list(messages) when is_list(messages) do
     messages
     |> PushMessage.create_from_list
-    # |> Enum.chunk_every(100)
     |> push_messages_list
   end
 

--- a/test/exponent_server_sdk/push_message_test.exs
+++ b/test/exponent_server_sdk/push_message_test.exs
@@ -15,11 +15,11 @@ defmodule ExponentServerSdk.PushMessageTest do
     }
 
     message = %PushMessage{
-      badge: nil,
+      badge: 1,
       body: "You got your first message",
-      channelId: nil,
-      data: nil,
-      expiration: nil,
+      channelId: "Default",
+      data: %{},
+      expiration: 2419200,
       priority: "default",
       sound: "default",
       title: "Pushed!",
@@ -47,11 +47,11 @@ defmodule ExponentServerSdk.PushMessageTest do
     messages = [
       [
         %PushMessage{
-          badge: nil,
+          badge: 1,
           body: "You got your first message",
-          channelId: nil,
-          data: nil,
-          expiration: nil,
+          channelId: "Default",
+          data: %{},
+          expiration: 2419200,
           priority: "default",
           sound: "default",
           title: "Pushed!",
@@ -59,11 +59,11 @@ defmodule ExponentServerSdk.PushMessageTest do
           ttl: 0
         },
         %PushMessage{
-          badge: nil,
+          badge: 1,
           body: "You got your second message",
-          channelId: nil,
-          data: nil,
-          expiration: nil,
+          channelId: "Default",
+          data: %{},
+          expiration: 2419200,
           priority: "default",
           sound: "default",
           title: "Pushed Again!",

--- a/test/exponent_server_sdk/push_notification_test.exs
+++ b/test/exponent_server_sdk/push_notification_test.exs
@@ -20,14 +20,15 @@ defmodule ExponentServerSdk.PushNotificationTest do
 
     with_fixture(:post!, json, fn ->
       # expected = {:ok, %{"status" => "ok", "id" => "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"}}
-      expected =
-        {:ok,
-         %{
-           "status" => "error",
-           "details" => %{"error" => "DeviceNotRegistered"},
-           "message" =>
-             "\"ExponentPushToken[XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX]\" is not a registered push notification recipient"
-         }}
+      expected = {:ok, %{"status" => "ok", "id" => "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"}}
+        # {:ok,
+        #  %{
+        #    "status" => "error",
+        #    "details" => %{"error" => "DeviceNotRegistered"},
+        #    "message" =>
+        #      "\"ExponentPushToken[XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX]\" is not a registered push notification recipient"
+        #  }}
+
 
       assert expected == PushNotification.push(message_map)
     end)
@@ -38,12 +39,14 @@ defmodule ExponentServerSdk.PushNotificationTest do
       %{
         to: "ExponentPushToken[XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX]",
         title: "Pushed!",
-        body: "You got your first message"
+        body: "You got your first message",
+        data: %{}
       },
       %{
         to: "ExponentPushToken[YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY]",
         title: "Pushed Again!",
-        body: "You got your second message"
+        body: "You got your second message",
+        data: %{}
       }
     ]
 
@@ -64,22 +67,24 @@ defmodule ExponentServerSdk.PushNotificationTest do
       #    %{"status" => "ok", "id" => "YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY"}
       #    ]
       #  }
-      expected =
-        {:ok,
-         [
-           %{
-             "status" => "error",
-             "details" => %{"error" => "DeviceNotRegistered"},
-             "message" =>
-               "\"ExponentPushToken[XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX]\" is not a registered push notification recipient"
-           },
-           %{
-             "status" => "error",
-             "details" => %{"error" => "DeviceNotRegistered"},
-             "message" =>
-               "\"ExponentPushToken[YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY]\" is not a registered push notification recipient"
-           }
-         ]}
+      expected = [
+        ok: [
+          %{
+            "details" => %{
+              "error" => "DeviceNotRegistered"
+            },
+            "message" => "\"ExponentPushToken[XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX]\" is not a registered push notification recipient",
+            "status" => "error"
+          },
+          %{
+            "details" => %{
+              "error" => "DeviceNotRegistered"
+            },
+            "message" => "\"ExponentPushToken[YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY]\" is not a registered push notification recipient",
+            "status" => "error"
+          }
+        ]
+      ]
 
       assert expected == PushNotification.push_list(message_list)
     end)
@@ -159,11 +164,11 @@ defmodule ExponentServerSdk.PushNotificationTest do
         [
           [
             %PushMessage{
-              badge: nil,
+              badge: 0,
               body: "You got your first message",
-              channelId: nil,
-              data: nil,
-              expiration: nil,
+              channelId: "Default",
+              data: %{},
+              expiration: 2419200,
               priority: "default",
               sound: "default",
               title: "Pushed!",
@@ -171,11 +176,11 @@ defmodule ExponentServerSdk.PushNotificationTest do
               ttl: 0
             },
             %PushMessage{
-              badge: nil,
+              badge: 0,
               body: "You got your second message",
-              channelId: nil,
-              data: nil,
-              expiration: nil,
+              channelId: "Default",
+              data: %{},
+              expiration: 2419200,
               priority: "default",
               sound: "default",
               title: "Pushed Again!",


### PR DESCRIPTION
This is not a final version but it attempts to address the main issues found and it got spread to other areas as a result of the initial change

The `push/1` & `push_list/1` functions are not currently using the advantages of having a custom struct `PushMessage`. Even further, both methods are piping the incoming message/s map/s in order to cast them but at the end of each method the orinal passed arguments are sent to Expo.
This just means that the incoming data could say anything because something else is being sent. And, also, lists are not being ckunked every 100, so it does't seem to be possible to send more than 100 push notifications

Again, this is not a final version but it may be a place to start the refactor
@rdrop 